### PR TITLE
feat(Jprotobuf): Avoid create lot of CodedOutputStream instance!

### DIFF
--- a/src/main/java/com/baidu/bjf/remoting/protobuf/code/CodecOutputByteArray.java
+++ b/src/main/java/com/baidu/bjf/remoting/protobuf/code/CodecOutputByteArray.java
@@ -1,0 +1,86 @@
+package com.baidu.bjf.remoting.protobuf.code;
+
+import com.baidu.bjf.remoting.protobuf.Codec;
+import com.google.protobuf.CodedOutputStream;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Stack;
+
+/***
+ * Get byte array from codec and object.
+ * Avoid create a lot of CodedOutputStream object.
+ *
+ * Borrow obj from this thread and recycle in this thread too.
+ * It not a real object pool. Just thread scope cache.
+ *
+ * @author qiunet
+ * 2022/8/12 14:23
+ */
+public class CodecOutputByteArray {
+    private static final ThreadLocal<Stack<CodecOutputByteArray>> instanceGetter = ThreadLocal.withInitial(Stack::new);
+    private final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    private final CodedOutputStream stream = CodedOutputStream.newInstance(byteArrayOutputStream, 0);
+    /**
+     * max retain object count
+     */
+    private static final int MAX_ELEMENT = 10;
+
+    private CodecOutputByteArray() {}
+    /**
+     * get CodecOutputByteArrayGetter from ThreadLocal
+     * @return CodecOutputByteArrayGetter instance
+     */
+    public static CodecOutputByteArray get() {
+        Stack<CodecOutputByteArray> stack = instanceGetter.get();
+        if (stack.size() > 0) {
+            return stack.pop();
+        }
+        return new CodecOutputByteArray();
+    }
+
+    /**
+     * get CodedOutputStream instance
+     * @return
+     */
+    public CodedOutputStream getCodedOutputStream() {
+        return stream;
+    }
+
+    /**
+     * get byte array data
+     * @return byte array
+     * @throws IOException
+     */
+    public byte[] getData() throws IOException {
+        this.stream.flush();
+        byte[] bytes = this.byteArrayOutputStream.toByteArray();
+        this.recycle();
+        return bytes;
+    }
+    /**
+     * get byte array from codec and object
+     * @param codec codec
+     * @param obj obj
+     * @return byte array
+     * @param <T>
+     * @throws IOException
+     */
+    public static <T> byte[] getData(Codec<T> codec, T obj) throws IOException {
+        CodecOutputByteArray data = get();
+        codec.writeTo(obj, data.stream);
+        return data.getData();
+    }
+    /**
+     * recycle instance.
+     */
+    private void recycle(){
+        this.byteArrayOutputStream.reset();
+        Stack<CodecOutputByteArray> stack = instanceGetter.get();
+        if (stack.size() >= MAX_ELEMENT) {
+            // drop object
+            return;
+        }
+        stack.push(this);
+    }
+}

--- a/src/main/java/com/baidu/bjf/remoting/protobuf/code/CodecOutputByteArray.java
+++ b/src/main/java/com/baidu/bjf/remoting/protobuf/code/CodecOutputByteArray.java
@@ -40,6 +40,20 @@ public class CodecOutputByteArray {
     }
 
     /**
+     * get thread scope size
+     * @return
+     */
+    public static int threadScopeSize() {
+        return instanceGetter.get().size();
+    }
+
+    /**
+     * clear stack
+     */
+    public static void clear() {
+        instanceGetter.get().clear();
+    }
+    /**
      * get CodedOutputStream instance
      * @return
      */

--- a/src/main/java/com/baidu/bjf/remoting/protobuf/code/CodedConstant.java
+++ b/src/main/java/com/baidu/bjf/remoting/protobuf/code/CodedConstant.java
@@ -721,16 +721,14 @@ public class CodedConstant {
             return;
         }
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        CodedOutputStream newInstance = CodedOutputStream.newInstance(baos, 0);
+        CodecOutputByteArray output = CodecOutputByteArray.get();
         for (Object object : list) {
             if (object == null) {
                 throw new NullPointerException("List can not include Null value.");
             }
-            writeObject(newInstance, order, type, object, true, !packed);
+            writeObject(output.getCodedOutputStream(), order, type, object, true, !packed);
         }
-        newInstance.flush();
-        byte[] byteArray = baos.toByteArray();
+        byte[] byteArray = output.getData();
 
         if (packed) {
             out.writeUInt32NoTag(makeTag(order, WireFormat.WIRETYPE_LENGTH_DELIMITED));
@@ -782,11 +780,7 @@ public class CodedConstant {
                 out.writeUInt32NoTag(makeTag(order, WireFormat.WIRETYPE_LENGTH_DELIMITED));
             }
 
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            CodedOutputStream newInstance = CodedOutputStream.newInstance(baos, 0);
-            target.writeTo(o, newInstance);
-            newInstance.flush();
-            byte[] byteArray = baos.toByteArray();
+            byte[] byteArray = CodecOutputByteArray.getData(target, o);
             out.writeUInt32NoTag(byteArray.length);
             out.write(byteArray, 0, byteArray.length);
 

--- a/src/main/resources/jprotobuf_classes_template.tpl
+++ b/src/main/resources/jprotobuf_classes_template.tpl
@@ -1,6 +1,5 @@
 ${package}
 
-import java.io.ByteArrayOutputStream;
 import java.io.Serializable;
 <!-- $BeginBlock imports -->
 import ${importPackage};
@@ -11,11 +10,9 @@ public class ${className} implements ${codecClassName}<${targetProxyClassName}>,
     private ${descriptorClsName} descriptor;
 
     public byte[] encode(${targetProxyClassName} t) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        CodedOutputStream newInstance = CodedOutputStream.newInstance(baos);
-        doWriteTo(t, newInstance);
-        newInstance.flush();
-        return baos.toByteArray();
+        CodecOutputByteArray output = CodecOutputByteArray.get();
+        doWriteTo(t, output.getCodedOutputStream());
+        return output.getData();
     }
 
     public ${targetProxyClassName} decode(byte[] bb) throws IOException {

--- a/src/test/java/com/baidu/bjf/remoting/protobuf/utils/CodecOutputByteArrayTest.java
+++ b/src/test/java/com/baidu/bjf/remoting/protobuf/utils/CodecOutputByteArrayTest.java
@@ -1,0 +1,85 @@
+package com.baidu.bjf.remoting.protobuf.utils;
+
+import com.baidu.bjf.remoting.protobuf.Codec;
+import com.baidu.bjf.remoting.protobuf.ProtobufProxy;
+import com.baidu.bjf.remoting.protobuf.annotation.Protobuf;
+import com.baidu.bjf.remoting.protobuf.annotation.ProtobufClass;
+import com.baidu.bjf.remoting.protobuf.code.CodecOutputByteArray;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/***
+ * test CodecOutputByteArray
+ *
+ * @author qiunet
+ * 2022/8/18 09:23
+ */
+public class CodecOutputByteArrayTest {
+
+    @Before
+    public void clear() {
+        CodecOutputByteArray.clear();
+    }
+
+    /**
+     * test recycle
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testRecycle() throws IOException {
+        CodecOutputByteArray obj1 = CodecOutputByteArray.get();
+        CodecOutputByteArray obj2 = CodecOutputByteArray.get();
+        obj2.getData();
+        obj1.getData();
+        CodecOutputByteArray obj3 = CodecOutputByteArray.get();
+        CodecOutputByteArray obj4 = CodecOutputByteArray.get();
+
+        Assert.assertSame(obj1, obj3);
+        Assert.assertSame(obj2, obj4);
+        // recycle
+        obj3.getData();
+        obj4.getData();
+
+        Assert.assertEquals(CodecOutputByteArray.threadScopeSize(), 2);
+    }
+
+    /**
+     * test reuse with codec output stream write
+     * @throws IOException
+     */
+    @Test
+    public void testReuseWithOutputStreamWrite() throws IOException {
+        CodecOutputByteArray obj1 = CodecOutputByteArray.get();
+        obj1.getCodedOutputStream().write((byte) 1);
+        byte[] data1 = obj1.getData();
+        Assert.assertArrayEquals(data1, new byte[]{1});
+
+        CodecOutputByteArray obj2 = CodecOutputByteArray.get();
+        Assert.assertSame(obj2, obj1);
+        obj2.getCodedOutputStream().write((byte)2);
+        byte[] data2 = obj2.getData();
+        Assert.assertArrayEquals(data2, new byte[]{2});
+
+        Assert.assertEquals(CodecOutputByteArray.threadScopeSize(), 1);
+    }
+
+    /**
+     * test reuse with codec
+     */
+    @Test
+    public void testReuseWithCodec() throws IOException {
+        Codec<TempObj> codec = ProtobufProxy.create(TempObj.class);
+        byte[] data1 = CodecOutputByteArray.getData(codec, new TempObj(1));
+        Assert.assertArrayEquals(data1, new byte[]{8, 1});
+
+        byte[] data2 = CodecOutputByteArray.getData(codec, new TempObj(2));
+        Assert.assertArrayEquals(data2, new byte[]{8, 2});
+
+        Assert.assertEquals(CodecOutputByteArray.threadScopeSize(), 1);
+    }
+}

--- a/src/test/java/com/baidu/bjf/remoting/protobuf/utils/TempObj.java
+++ b/src/test/java/com/baidu/bjf/remoting/protobuf/utils/TempObj.java
@@ -1,0 +1,29 @@
+package com.baidu.bjf.remoting.protobuf.utils;
+
+import com.baidu.bjf.remoting.protobuf.annotation.Protobuf;
+import com.baidu.bjf.remoting.protobuf.annotation.ProtobufClass;
+
+/***
+ * for test
+ * @author qiunet
+ * 2022/8/18 09:36
+ */
+@ProtobufClass
+public class TempObj {
+    @Protobuf
+    private int val;
+
+    public TempObj() {}
+
+    public TempObj(int val) {
+        this.val = val;
+    }
+
+    public int getVal() {
+        return val;
+    }
+
+    public void setVal(int val) {
+        this.val = val;
+    }
+}


### PR DESCRIPTION
压测在线3K.  每秒每人发30包 收20包. 每次ygc(11秒). 会创建两千万的CodedOutputStream 和 ByteArrayOutputStream. 和大量的字节数组对象

       2:      23799859      951994360  com.google.protobuf.CodedOutputStream$OutputStreamEncoder
       3:      23800055      571201320  java.io.ByteArrayOutputStream


因为处理序列化和反序列化没有切换线程, 可以使用ThreadLocal做对象缓存优化. 优化后, 几乎可以忽略.  我这固定是160个对象.  YGC时间也延长到18秒.

       388:           160           6400  com.google.protobuf.CodedOutputStream$OutputStreamEncoder
       361:           421          10104  java.io.ByteArrayOutputStream

但是使用ByteBuffer构造CodedOutputStream 以及 CodedInputStream ,我没有找到好的优化方案
