### PR TITLE
Update ProtobufProxy.java

### DIFF
--- a/src/main/java/com/baidu/bjf/remoting/protobuf/ProtobufProxy.java
+++ b/src/main/java/com/baidu/bjf/remoting/protobuf/ProtobufProxy.java
@@ -189,7 +189,7 @@ public final class ProtobufProxy {
      * @return {@link Codec} instance proxy
      */
     public static <T> Codec<T> create(Class<T> cls, Compiler compiler, ICodeGenerator codeGenerator) {
-        return create(cls, isDebugEnabled(), null, compiler, getCodeGenerator(cls));
+        return create(cls, isDebugEnabled(), null, compiler, codeGenerator);
     }
 
     /**


### PR DESCRIPTION
bugfix 参数未引用，导致传递进来的不能使用