### PR TITLE
update `auto.value.version` from 1.0 to 1.11.0 and fix break change.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 		<java.version>1.8</java.version>
 		<junit.version>4.13.1</junit.version>
-		<auto.value.version>1.0</auto.value.version>
+		<auto.value.version>1.11.0</auto.value.version>
 	</properties>
 
 	<issueManagement>

--- a/src/test/java/com/baidu/bjf/remoting/protobuf/computeSize/TestComputeSize.java
+++ b/src/test/java/com/baidu/bjf/remoting/protobuf/computeSize/TestComputeSize.java
@@ -1,6 +1,6 @@
 package com.baidu.bjf.remoting.protobuf.computeSize;
 
-import autovalue.shaded.com.google.common.common.collect.Lists;
+import autovalue.shaded.com.google.common.collect.Lists;
 import com.baidu.bjf.remoting.protobuf.Codec;
 import com.baidu.bjf.remoting.protobuf.ProtobufProxy;
 import org.junit.Assert;


### PR DESCRIPTION
update `auto.value.version` from 1.0 to 1.11.0 and fix break change.