### PR TITLE
JdkCompiler在JDK21下"nested:"问题修改

### DIFF
--- a/src/main/java/com/baidu/bjf/remoting/protobuf/utils/FieldUtils.java
+++ b/src/main/java/com/baidu/bjf/remoting/protobuf/utils/FieldUtils.java
@@ -197,13 +197,17 @@ public final class FieldUtils {
             // file.
             Field[] fields = targetClass.getDeclaredFields();
             for (int i = 0; i < fields.length; i++) {
+                Field  field = fields[i];
+                if(field.isSynthetic()){
+                    continue;           //skip compiler-generated fields
+                }
                 if (ann == null) {
-                    ret.add(fields[i]);
+                    ret.add(field);
                     continue;
                 }
-                Annotation protobuf = fields[i].getAnnotation(ann);
+                Annotation protobuf = field.getAnnotation(ann);
                 if (protobuf != null) {
-                    ret.add(fields[i]);
+                    ret.add(field);
                 }
             }
             targetClass = targetClass.getSuperclass();

--- a/src/main/java/com/baidu/bjf/remoting/protobuf/utils/compiler/JdkCompiler.java
+++ b/src/main/java/com/baidu/bjf/remoting/protobuf/utils/compiler/JdkCompiler.java
@@ -136,7 +136,6 @@ public class JdkCompiler extends AbstractCompiler {
                 for (URL url : urlClassLoader.getURLs()) {
                     
                     String file = url.getFile();
-                    files.add(new File(file));
                     if (StringUtils.endsWith(file, "!/")) {
                         file = StringUtils.removeEnd(file, "!/");
                     }


### PR DESCRIPTION
1.去掉139行的:files.add(new File(file)),只用,在对file各种判断和替换完成之后,添加一次就可以了.
2.根据反射JAVA类处理PB生成字段时跳过编译生成的字段。
如JDK21会根据switch语句,生成类似：
private static volatile synthetic [I $SWITCH_TABLE$.....的字段
